### PR TITLE
Potential fix for code scanning alert no. 5: Information exposure through a stack trace

### DIFF
--- a/netlify/functions/getStripePrices.mts
+++ b/netlify/functions/getStripePrices.mts
@@ -52,7 +52,8 @@ export default async function handler(request: Request, context: Context) {
                 try {
                     await stripe.products.update(stripeItem.id, {default_price: price.id})
                 } catch (error) {
-                    return new Response(JSON.stringify(error), {status: 500})
+                    console.error("Error updating product default price:", error);
+                    return new Response(JSON.stringify({error: "Internal server error"}), {status: 500});
                 }
             }
 
@@ -87,7 +88,8 @@ export default async function handler(request: Request, context: Context) {
                     return new Response(undefined, {status: 502, statusText: "An item failed to create on Stripe"})
                 }
             } catch (error) {
-                return new Response(undefined, {status: 500, statusText: JSON.stringify(error)})
+                console.error("Error creating product on Stripe:", error);
+                return new Response(undefined, {status: 500, statusText: "Internal server error"});
             }
         }
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Lordimass/TSISG-Webshop/security/code-scanning/5](https://github.com/Lordimass/TSISG-Webshop/security/code-scanning/5)

To fix this information exposure problem, error details must not be returned directly to the user. Instead, catch blocks should return a generic error message, and optionally log the full error server-side for diagnostics. Specifically, in `netlify/functions/getStripePrices.mts`, line 55 should be changed so that the response only contains a generic error message (e.g., "Internal server error"). Additionally, error details (`error`) should be logged to the console or a proper logging facility to aid diagnostics without leaking to users.

There is no need to change the functionality outside of returning generic error responses in the affected catch blocks. Ensure that line 55's response gives a generic message, such as:
```js
return new Response(JSON.stringify({error: "Internal server error"}), {status: 500})
```
The error details can be logged for developer reference (using `console.error(error)`).

Apply similar reasoning to line 91 as well, although the current statusText usage is unlikely to leak stack traces. However, for uniformity and defense-in-depth, ensure only generic error details reach users.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
